### PR TITLE
tests: log unique mpiexec instead of multiple a.out

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -50,7 +50,7 @@ TESTS =
 XFAIL_TESTS = 
 
 MPIEXEC = mpiexec -n 2
-TESTS_ENVIRONMENT = $(MPIEXEC)
+LOG_COMPILER=$(MPIEXEC)
 
 include benchmarks/Makefile.mk
 include tests/Makefile.mk


### PR DESCRIPTION
and have ```make check``` print only one line per test