### PR TITLE
do not install internal headers

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -42,7 +42,8 @@ libarmci_la_LDFLAGS = -version-info $(libarmci_abi_version)
 libarmcii_la_SOURCES = $(libarmci_la_SOURCES)
 libarmcii_la_LDFLAGS = $(libarmci_abi_version)
 
-include_HEADERS = src/armciconf.h src/armci.h src/armci_internals.h src/armcix.h src/conflict_tree.h src/debug.h src/gmr.h src/message.h src/mp3.h
+include_HEADERS = src/armci.h src/armcix.h src/message.h src/mp3.h src/armciconf.h
+noinst_HEADERS = src/armci_internals.h src/conflict_tree.h src/debug.h src/gmr.h
 
 bin_PROGRAMS =
 check_PROGRAMS = 


### PR DESCRIPTION
see discussion on https://github.com/jeffhammond/armci-mpi/issues/4

armciconf.h is only required by armcix.h, which is only used in
ARMCI-MPI tests.  neither header is used by GA.