### PR TITLE
make explicit NB progress a runtime option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -164,16 +164,6 @@ if test "$armci_group_enabled" = "yes"; then
    AC_DEFINE(ARMCI_GROUP,1,[Defined when ARMCI subset-collective group formation is enabled])
 fi
 
-## Make explicit progress in nonblocking operations
-AC_ARG_ENABLE(explicit-progress, AC_HELP_STRING([--enable-explicit-progress],[Enable explicit MPI progress during nonblocking calls]),
-                 [ explicit_progress_enabled=$enableval ],
-                 [ explicit_progress_enabled=no ])
-AC_MSG_CHECKING(whether explicit MPI progress during nonblocking calls is enabled)
-AC_MSG_RESULT($explicit_progress_enabled)
-if test "$explicit_progress_enabled" = "yes"; then
-   AC_DEFINE(EXPLICIT_PROGRESS,1,[Defined when explicit MPI progress during nonblocking calls is enabled])
-fi
-
 ## Active MPI_Win_allocate when we know it works
 AC_ARG_ENABLE(win-allocate, AC_HELP_STRING([--enable-win-allocate],[Use MPI_WIN_ALLOCATE.]),
                  [ win_allocate_enabled=$enableval ],

--- a/src/armci_internals.h
+++ b/src/armci_internals.h
@@ -83,6 +83,7 @@ typedef struct {
   int           progress_usleep;        /* Argument to usleep() to throttling polling                           */
 #endif
   int           use_win_allocate;       /* Use win_allocate or win_create                                       */
+  int           explicit_nb_progress;   /* Poke the MPI progress engine at the end of nonblocking (NB) calls    */
   int           use_alloc_shm;          /* Pass alloc_shm info to win_allocate / alloc_mem                      */
   int           rma_atomicity;          /* Use Accumulate and Get_accumulate for Put and Get                    */
   int           end_to_end_flush;       /* All flush_local calls become flush                                   */

--- a/src/gmr-extras.c
+++ b/src/gmr-extras.c
@@ -203,8 +203,10 @@ int gmr_sync(gmr_t *mreg) {
 
 void gmr_progress(void)
 {
-    int flag;
-    MPI_Iprobe(MPI_ANY_SOURCE, MPI_ANY_TAG, ARMCI_GROUP_WORLD.comm, &flag, MPI_STATUS_IGNORE);
+    if (ARMCII_GLOBAL_STATE.explicit_nb_progress) {
+        int flag;
+        MPI_Iprobe(MPI_ANY_SOURCE, MPI_ANY_TAG, ARMCI_GROUP_WORLD.comm, &flag, MPI_STATUS_IGNORE);
+    }
     return;
 }
 

--- a/src/init_finalize.c
+++ b/src/init_finalize.c
@@ -227,6 +227,10 @@ int PARMCI_Init(void) {
 #endif
   ARMCII_GLOBAL_STATE.use_win_allocate=ARMCII_Getenv_bool("ARMCI_USE_WIN_ALLOCATE", win_alloc_default);
 
+  /* Poke the MPI progress engine at the end of nonblocking (NB) calls */
+
+  ARMCII_GLOBAL_STATE.explicit_nb_progress=ARMCII_Getenv_bool("ARMCI_EXPLICIT_NB_PROGRESS", 1);
+
   /* Pass alloc_shm to win_allocate / alloc_mem */
 
   ARMCII_GLOBAL_STATE.use_alloc_shm=ARMCII_Getenv_bool("ARMCI_USE_ALLOC_SHM", 1);

--- a/src/onesided_nb.c
+++ b/src/onesided_nb.c
@@ -84,9 +84,7 @@ int PARMCI_NbPut(void *src, void *dst, int size, int target, armci_hdl_t *handle
       handle->target = target;
   }
 
-#ifdef EXPLICIT_PROGRESS
   gmr_progress();
-#endif
 
   return 0;
 }
@@ -130,9 +128,7 @@ int PARMCI_NbGet(void *src, void *dst, int size, int target, armci_hdl_t *handle
       handle->target = target;
   }
 
-#ifdef EXPLICIT_PROGRESS
   gmr_progress();
-#endif
 
   return 0;
 }
@@ -209,9 +205,7 @@ int PARMCI_NbAcc(int datatype, void *scale, void *src, void *dst, int bytes, int
       handle->target = target;
   }
 
-#ifdef EXPLICIT_PROGRESS
   gmr_progress();
-#endif
 
   return 0;
 }

--- a/src/strided_nb.c
+++ b/src/strided_nb.c
@@ -116,9 +116,7 @@ int PARMCI_NbPutS(void *src_ptr, int src_stride_ar[/*stride_levels*/],
     free(iov.dst_ptr_array);
   }
 
-#ifdef EXPLICIT_PROGRESS
   gmr_progress();
-#endif
 
   return err;
 }
@@ -227,9 +225,7 @@ int PARMCI_NbGetS(void *src_ptr, int src_stride_ar[/*stride_levels*/],
     free(iov.dst_ptr_array);
   }
 
-#ifdef EXPLICIT_PROGRESS
   gmr_progress();
-#endif
 
   return err;
 }
@@ -379,9 +375,7 @@ int PARMCI_NbAccS(int datatype, void *scale,
     free(iov.dst_ptr_array);
   }
 
-#ifdef EXPLICIT_PROGRESS
   gmr_progress();
-#endif
 
   return err;
 }

--- a/src/vector_nb.c
+++ b/src/vector_nb.c
@@ -56,9 +56,7 @@ int PARMCI_NbPutV(armci_giov_t *iov, int iov_len, int proc, armci_hdl_t* handle)
       handle->target = proc;
   }
 
-#ifdef EXPLICIT_PROGRESS
   gmr_progress();
-#endif
 
   return 0;
 }
@@ -111,9 +109,7 @@ int PARMCI_NbGetV(armci_giov_t *iov, int iov_len, int proc, armci_hdl_t* handle)
       handle->target = proc;
   }
 
-#ifdef EXPLICIT_PROGRESS
   gmr_progress();
-#endif
 
   return 0;
 }
@@ -165,9 +161,7 @@ int PARMCI_NbAccV(int datatype, void *scale, armci_giov_t *iov, int iov_len, int
       handle->target = proc;
   }
 
-#ifdef EXPLICIT_PROGRESS
   gmr_progress();
-#endif
 
   return 0;
 }


### PR DESCRIPTION
remove configure support, set it by default, and let users disable at
runtime if appropriate.