### PR TITLE
MPI_Win_allocate is default, runtime option only

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -174,16 +174,6 @@ if test "$explicit_progress_enabled" = "yes"; then
    AC_DEFINE(EXPLICIT_PROGRESS,1,[Defined when explicit MPI progress during nonblocking calls is enabled])
 fi
 
-## Active MPI_Win_allocate when we know it works
-AC_ARG_ENABLE(win-allocate, AC_HELP_STRING([--enable-win-allocate],[Use MPI_WIN_ALLOCATE.]),
-                 [ win_allocate_enabled=$enableval ],
-                 [ win_allocate_enabled=no ])
-AC_MSG_CHECKING(whether MPI_WIN_ALLOCATE will be used)
-AC_MSG_RESULT($win_allocate_enabled)
-if test "$win_allocate_enabled" = "yes"; then
-   AC_DEFINE(USE_WIN_ALLOCATE,1,[Defined when the use of MPI_WIN_ALLOCATE is enabled])
-fi
-
 # Check for support for weak symbols.
 AC_ARG_ENABLE(weak-symbols, AC_HELP_STRING([--enable-weak-symbols],
                  [Use weak symbols to implement PARMCI routines (default)]),,

--- a/src/init_finalize.c
+++ b/src/init_finalize.c
@@ -220,11 +220,7 @@ int PARMCI_Init(void) {
 
   /* Use win_allocate or not, to work around MPI-3 RMA implementation bugs (now fixed) in MPICH. */
 
-#ifdef USE_WIN_ALLOCATE
   int win_alloc_default = 1;
-#else
-  int win_alloc_default = 0;
-#endif
   ARMCII_GLOBAL_STATE.use_win_allocate=ARMCII_Getenv_bool("ARMCI_USE_WIN_ALLOCATE", win_alloc_default);
 
   /* Pass alloc_shm to win_allocate / alloc_mem */


### PR DESCRIPTION
we are far enough past the bug that motivated this.  make it the default
and users can disable at runtime if necessary.