### PR TITLE
Add MPI_Win_free in gmr_create when aggregate_size = 0

### DIFF
--- a/src/gmr.c
+++ b/src/gmr.c
@@ -120,6 +120,7 @@ gmr_t *gmr_create(gmr_size_t local_size, void **base_ptrs, ARMCI_Group *group) {
   if (aggregate_size == 0) {
     free(alloc_slices);
     free(mreg->slices);
+    MPI_Win_free(&mreg->window);
     free(mreg);
 
     for (i = 0; i < alloc_nproc; i++)


### PR DESCRIPTION
If aggregate_size = 0 in gmr_create, a NULL vector is returned.
Allocated window is also required to be freed.